### PR TITLE
Update code and enable update checks

### DIFF
--- a/AutomatedDoors/AutomatedDoors.csproj
+++ b/AutomatedDoors/AutomatedDoors.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>AutomatedDoors</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
     <DeployModFolderName>$(MSBuildProjectName)</DeployModFolderName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -34,12 +32,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -48,11 +40,15 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="manifest.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <None Include="manifest.json" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+  </Target>
 </Project>

--- a/AutomatedDoors/manifest.json
+++ b/AutomatedDoors/manifest.json
@@ -1,13 +1,10 @@
 {
   "Name": "AutomatedDoors",
   "Author": "Phate, SMAPI 2.0+ patch by Disiesel, azah",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 4,
-    "PatchVersion": 1,
-    "Build": "1"
-  },
+  "Version": "1.4.1",
   "Description": "Automate opening & closing of farm building doors.",
   "UniqueID": "azah.automated-doors",
-  "EntryDll": "AutomatedDoors.dll"
+  "EntryDll": "AutomatedDoors.dll",
+  "MinimumApiVersion": "2.0",
+  "UpdateKeys": [ "GitHub:azah/AutomatedDoors" ]
 }

--- a/AutomatedDoors/manifest.json
+++ b/AutomatedDoors/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "AutomatedDoors",
   "Author": "Phate, SMAPI 2.0+ patch by Disiesel, azah",
-  "Version": "1.4.1",
+  "Version": "1.4.2",
   "Description": "Automate opening & closing of farm building doors.",
   "UniqueID": "azah.automated-doors",
   "EntryDll": "AutomatedDoors.dll",

--- a/AutomatedDoors/packages.config
+++ b/AutomatedDoors/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net452" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This pull request...
* Enables [automatic update checks](https://stardewvalleywiki.com/Modding:SMAPI_APIs#Update_checks).
* Updates the [mod build package](https://www.nuget.org/packages/Pathoschild.Stardew.ModBuildConfig).  
  _The new version automatically deploys the mod to your `Mods` folder, and automatically creates a release zip in the `bin` folder._
* Updates the `manifest.json` format.
* Bumps the mod version for release.

If these changes look fine, can you release [AutomatedDoors 1.4.2.zip](https://github.com/azah/AutomatedDoors/files/1778813/AutomatedDoors.1.4.2.zip)?